### PR TITLE
Fixed for datalib's rename of bin() to bins()

### DIFF
--- a/src/transforms/Bin.js
+++ b/src/transforms/Bin.js
@@ -22,7 +22,7 @@ proto.transform = function(input) {
   var transform = this,
       output = this._output.bin;
       
-  var b = dl.bin({
+  var b = dl.bins({
     min: this.min.get(),
     max: this.max.get(),
     step: this.step.get(),


### PR DESCRIPTION
Commit https://github.com/uwdata/datalib/commit/a325831cc20cb691ea102d37540bca42c7ddca09 broke the Bin tests due to a rename of the "bin" function to "bins".
