### PR TITLE
Removed the invalid parameters "width" and "height" from the "text" mark

### DIFF
--- a/examples/spec/dimpvis.json
+++ b/examples/spec/dimpvis.json
@@ -186,8 +186,6 @@
           "text": {"signal": "year"},
           "x": {"value": 300},
           "y": {"value": 300},
-          "width": {"value": 100},
-          "height": {"value": "auto"},
           "fill": {"value": "grey"},
           "fillOpacity": {"value": 0.25},
           "fontSize": {"value": 100}


### PR DESCRIPTION
"width" and "height" aren't valid text attributes (and the "auto" value for "height" is also not valid). Please correct me if I am wrong on this.
