### PR TITLE
disable loading of canvas in browser enviroments. Helpful for webpack…

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
   "scripts": {
     "test": "gulp test"
   },
+  "browser": {
+    "canvas": false
+  },
   "browserify": {
     "transform": [
       "browserify-shim"


### PR DESCRIPTION
… and other CommonJS builds

Right now we have browserify-specific fields in the `package.json` which is fine, but it doesn't help with other build systems. I ran into a problem where Webpack was loading `node-canvas` for browser builds. 

There are some solutions, such as 
1. `canvas-browserify` (suggested here: https://github.com/trifacta/vega/issues/235) 
2. Do what d3 did recently with jsdom: they just moved it into the devDependencies. While it isn't semantic usage of package.json, it worked. 

I _think_ this is the more generalized approach to dealing with the problem and recommended by Webpack (https://github.com/webpack/webpack/issues/553):
https://gist.github.com/defunctzombie/4339901#ignore-a-module

I implemented it and it worked. 

this fix is related to: https://github.com/trifacta/vega/issues/274 and https://github.com/trifacta/vega/issues/235
