### PR TITLE
Fix for a bug in canvas marks' stroke width

### DIFF
--- a/src/render/canvas/marks.js
+++ b/src/render/canvas/marks.js
@@ -332,7 +332,7 @@ function drawText(g, scene, bounds) {
       lw = (lw = o.strokeWidth) != null ? lw : 1;
       if (lw > 0) {
         g.globalAlpha = opac * (o.strokeOpacity==null ? 1 : o.strokeOpacity);
-        g.strokeStyle = color(o, stroke);
+        g.strokeStyle = color(g, o, stroke);
         g.lineWidth = lw;
         g.strokeText(o.text, x, y);
       }


### PR DESCRIPTION
The `color()` method is incorrectly invoked without the `g` parameter, causing an error to be thrown. This only happens when setting `strokeWidth` on a mark in `"canvas"` rendering mode.
