### PR TITLE
Fixed properties "name" to be an object of type string

### DIFF
--- a/src/parse/properties.js
+++ b/src/parse/properties.js
@@ -360,7 +360,7 @@ function valueSchema(type) {
                     {"type": "string"}, 
                     {
                       "type": "object",
-                      "properties": {"name": "string"},
+                      "properties": {"name": { "type": "string" }},
                       "required": ["name"]
                     }
                   ]


### PR DESCRIPTION
"properties" takes an object of keys to objects, not keys to strings.

I'm surprised the schema validator is not catching these typos. Maybe z-schema would?
