### PR TITLE
Adds "name" property to spec schema

### DIFF
--- a/src/parse/spec.js
+++ b/src/parse/spec.js
@@ -46,6 +46,7 @@ parseSpec.schema = {
 
       "allOf": [{"$ref": "#/defs/container"}, {
         "properties": {
+          "name": {"type": "string"},
           "width": {"type": "number"},
           "height": {"type": "number"},
           "viewport": {


### PR DESCRIPTION
Many of the example specs have a top-level "name" field, but it is not represented in the schema.
