### PR TITLE
Separate stringModifiers and numberModifiers

### DIFF
--- a/src/parse/properties.js
+++ b/src/parse/properties.js
@@ -332,10 +332,11 @@ function scaleRef(ref) {
 module.exports = properties;
 
 function valueSchema(type) {
+  var mods = type == "number" ? "numberModifiers" : "stringModifiers"
   type = util.isArray(type) ? {"enum": type} : {"type": type};
   var valRef = {
     "type": "object",
-    "allOf": [{"$ref": "#/refs/valueModifiers"}, {
+    "allOf": [{"$ref": "#/refs/" + mods}, {
       "oneOf": [{
         "$ref": "#/refs/signal",
         "required": ["signal"]
@@ -444,7 +445,13 @@ properties.schema = {
       ]
     },
 
-    "valueModifiers": {
+    "stringModifiers": {
+      "properties": {
+        "scale": {"$ref": "#/refs/scale"}
+      }
+    },
+
+    "numberModifiers": {
       "properties": {
         "mult": {"type": "number"},
         "offset": {"type": "number"},


### PR DESCRIPTION
String values can't take an "offset" or "mult", so have a separate "stringModifiers" and "numberModifiers" ref.
